### PR TITLE
Tag 저장 및 확인 기능 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'commons-fileupload:commons-fileupload:1.4'
     implementation 'org.modelmapper:modelmapper:3.1.1'
-    implementation 'org.mariadb.jdbc:mariadb-java-client:3.0.6'
+    //implementation 'org.mariadb.jdbc:mariadb-java-client:3.0.6'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     compileOnly 'org.projectlombok:lombok'
-    //runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'junit:junit:4.13.2'

--- a/src/main/java/apptive/fruitable/board/controller/PostController.java
+++ b/src/main/java/apptive/fruitable/board/controller/PostController.java
@@ -1,7 +1,7 @@
 package apptive.fruitable.board.controller;
 
-import apptive.fruitable.board.dto.PostDto;
-import apptive.fruitable.board.dto.PostRequestDto;
+import apptive.fruitable.board.dto.post.PostDto;
+import apptive.fruitable.board.dto.post.PostRequestDto;
 import apptive.fruitable.board.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,10 +52,11 @@ public class PostController {
                     MediaType.MULTIPART_FORM_DATA_VALUE})
     @ResponseStatus(HttpStatus.CREATED)
     public Long write(@Valid @RequestPart(value = "requestDto") PostRequestDto requestDto,
-                      @RequestPart(value = "images") List<MultipartFile> photoFileList
+                      @RequestPart(value = "images") List<MultipartFile> photoFileList,
+                      @RequestPart(value = "tags") List<String> contentList
                       ) throws Exception {
 
-        return postService.savePost(requestDto, photoFileList);
+        return postService.savePost(requestDto, photoFileList, contentList);
     }
 
     /**

--- a/src/main/java/apptive/fruitable/board/domain/post/Post.java
+++ b/src/main/java/apptive/fruitable/board/domain/post/Post.java
@@ -1,6 +1,7 @@
 package apptive.fruitable.board.domain.post;
 
-import apptive.fruitable.board.dto.PostRequestDto;
+import apptive.fruitable.board.domain.tag.Tag;
+import apptive.fruitable.board.dto.post.PostRequestDto;
 import apptive.fruitable.converter.StringListConverter;
 import apptive.fruitable.login.entity.MemberEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -27,6 +28,10 @@ public class Post {
     @JsonIgnore
     //@JoinColumn(name = "member_id")
     private MemberEntity userId;
+
+    @Convert(converter = StringListConverter.class)
+    private List<String> tagList;
+
     @Column(nullable = false, length = 20)
     private String contact;
 
@@ -40,8 +45,6 @@ public class Post {
     @Column(nullable = false)
     private Integer price;
     private LocalDate endDate;
-    @Convert(converter = StringListConverter.class)
-    private List<String> tags;
 
     @Column
     @Convert(converter = StringListConverter.class)
@@ -59,6 +62,5 @@ public class Post {
         this.content =  postDto.getContent();
         this.price = postDto.getPrice();
         this.endDate = postDto.getEndDate();
-        this.tags = postDto.getTags();
     }
 }

--- a/src/main/java/apptive/fruitable/board/domain/tag/Tag.java
+++ b/src/main/java/apptive/fruitable/board/domain/tag/Tag.java
@@ -1,0 +1,30 @@
+package apptive.fruitable.board.domain.tag;
+
+import apptive.fruitable.board.domain.post.Post;
+import apptive.fruitable.board.dto.tag.TagDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "tag")
+public class Tag {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long tagId;
+
+    @ManyToOne
+    private Post post;
+
+    @Getter
+    private String tagContent;
+
+    public void makeTag(TagDto tagDto) {
+
+        this.post = tagDto.getPost();
+        this.tagContent = tagDto.getTagContent();
+    }
+}

--- a/src/main/java/apptive/fruitable/board/dto/post/PostDto.java
+++ b/src/main/java/apptive/fruitable/board/dto/post/PostDto.java
@@ -1,24 +1,27 @@
-package apptive.fruitable.board.dto;
+package apptive.fruitable.board.dto.post;
 
 import apptive.fruitable.board.domain.post.Post;
+import apptive.fruitable.board.domain.tag.Tag;
 import apptive.fruitable.login.entity.MemberEntity;
 import lombok.Getter;
 import lombok.Setter;
 import org.modelmapper.ModelMapper;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Component;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-@Setter
+@Getter @Setter
 @Component
-public class PostRequestDto {
+public class PostDto {
+
+    private Long id;
 
     private MemberEntity userId;
+    private List<String> tagList;
 
     @NotBlank(message = "연락처를 입력해 주세요")
     private String contact;
@@ -30,22 +33,19 @@ public class PostRequestDto {
     private String content;
     @NotNull(message = "가격을 입력해주세요")
     private Integer price;
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
-    private List<String> tags;
+
+    private List<String> filePath = new ArrayList<>();
+    private List<String> fileURL = new ArrayList<>();
 
     private static ModelMapper modelMapper = new ModelMapper();
 
     public Post createPost() {
-        /*modelMapper.getConfiguration()
-                .setFieldAccessLevel(Configuration.AccessLevel.PRIVATE)
-                .setFieldMatchingEnabled(true);*/
         return modelMapper.map(this, Post.class);
     }
 
-    public static PostRequestDto of(Post post) {
-        return modelMapper.map(post, PostRequestDto.class);
+    public static PostDto of(Post post) {
+        return modelMapper.map(post, PostDto.class);
     }
 
 }
-

--- a/src/main/java/apptive/fruitable/board/dto/post/PostRequestDto.java
+++ b/src/main/java/apptive/fruitable/board/dto/post/PostRequestDto.java
@@ -1,23 +1,21 @@
-package apptive.fruitable.board.dto;
+package apptive.fruitable.board.dto.post;
 
 import apptive.fruitable.board.domain.post.Post;
 import apptive.fruitable.login.entity.MemberEntity;
 import lombok.Getter;
 import lombok.Setter;
 import org.modelmapper.ModelMapper;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Component;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
-@Getter @Setter
+@Getter
+@Setter
 @Component
-public class PostDto {
-
-    private Long id;
+public class PostRequestDto {
 
     private MemberEntity userId;
 
@@ -31,20 +29,21 @@ public class PostDto {
     private String content;
     @NotNull(message = "가격을 입력해주세요")
     private Integer price;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
-    private List<String> tags = new ArrayList<>();
-
-    private List<String> filePath = new ArrayList<>();
-    private List<String> fileURL = new ArrayList<>();
 
     private static ModelMapper modelMapper = new ModelMapper();
 
     public Post createPost() {
+        /*modelMapper.getConfiguration()
+                .setFieldAccessLevel(Configuration.AccessLevel.PRIVATE)
+                .setFieldMatchingEnabled(true);*/
         return modelMapper.map(this, Post.class);
     }
 
-    public static PostDto of(Post post) {
-        return modelMapper.map(post, PostDto.class);
+    public static PostRequestDto of(Post post) {
+        return modelMapper.map(post, PostRequestDto.class);
     }
 
 }
+

--- a/src/main/java/apptive/fruitable/board/dto/tag/TagDto.java
+++ b/src/main/java/apptive/fruitable/board/dto/tag/TagDto.java
@@ -1,0 +1,12 @@
+package apptive.fruitable.board.dto.tag;
+
+import apptive.fruitable.board.domain.post.Post;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class TagDto {
+
+    private Post post;
+    private String tagContent;
+}

--- a/src/main/java/apptive/fruitable/board/repository/TagRepository.java
+++ b/src/main/java/apptive/fruitable/board/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package apptive.fruitable.board.repository;
+
+import apptive.fruitable.board.domain.tag.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/apptive/fruitable/board/service/PostService.java
+++ b/src/main/java/apptive/fruitable/board/service/PostService.java
@@ -1,8 +1,9 @@
 package apptive.fruitable.board.service;
 
 import apptive.fruitable.board.domain.post.Post;
-import apptive.fruitable.board.dto.PostDto;
-import apptive.fruitable.board.dto.PostRequestDto;
+import apptive.fruitable.board.domain.tag.Tag;
+import apptive.fruitable.board.dto.post.PostDto;
+import apptive.fruitable.board.dto.post.PostRequestDto;
 import apptive.fruitable.board.handler.S3Uploader;
 import apptive.fruitable.board.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import java.util.List;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final TagService tagService;
     private final S3Uploader s3Uploader;
 
     /**
@@ -30,10 +32,15 @@ public class PostService {
      */
     @Transactional
     public Long savePost(PostRequestDto requestDto,
-                         List<MultipartFile> files) throws Exception {
+                         List<MultipartFile> files,
+                         List<String> contentList) throws Exception {
 
         Post post = new Post();
         post.updatePost(requestDto);
+
+        //태그 등록
+        List<String> tagList = tagService.saveTag(post, contentList);
+        post.setTagList(tagList);
 
         //이미지 등록
         List<String> filePath = s3Uploader.uploadFiles(files);

--- a/src/main/java/apptive/fruitable/board/service/TagService.java
+++ b/src/main/java/apptive/fruitable/board/service/TagService.java
@@ -1,0 +1,42 @@
+package apptive.fruitable.board.service;
+
+import apptive.fruitable.board.domain.post.Post;
+import apptive.fruitable.board.domain.tag.Tag;
+import apptive.fruitable.board.dto.tag.TagDto;
+import apptive.fruitable.board.repository.PostRepository;
+import apptive.fruitable.board.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public List<String> saveTag(Post post, List<String> contentList) {
+
+        List<String> tagList = new ArrayList<>();
+
+        for(String content : contentList) {
+
+            TagDto tagDto = new TagDto();
+            tagDto.setPost(post);
+            tagDto.setTagContent(content);
+
+            Tag tag = new Tag();
+            tag.makeTag(tagDto);
+
+            tagList.add(tag.getTagContent());
+
+            tagRepository.save(tag);
+        }
+
+        return tagList;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,8 @@ cloud:
     s3:
       bucket: fruitable-bucket
     credentials:
-      access-key: AKIA36W7FXMSOMKY4IGK
-      secret-key: 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
+      access-key:
+      secret-key:
     region:
       static: ap-northeast-2
       auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:mariadb://fruitable.cvjiwbuuly4r.ap-northeast-2.rds.amazonaws.com:3306/fruitable #jdbc:h2:tcp://localhost/~/fruitable
-    username:
+    url: jdbc:h2:tcp://localhost/~/fruitable #jdbc:mariadb://fruitable.cvjiwbuuly4r.ap-northeast-2.rds.amazonaws.com:3306/fruitable
+    username: sa
     password:
-    driver-class-name: org.mariadb.jdbc.Driver #org.h2.Driver
+    driver-class-name: org.h2.Driver #org.mariadb.jdbc.Driver
 
   # Naver smtp server 사용
   mail:
@@ -56,7 +56,7 @@ cloud:
       bucket: fruitable-bucket
     credentials:
       access-key: AKIA36W7FXMSOMKY4IGK
-      secret-key:
+      secret-key: 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
     region:
       static: ap-northeast-2
       auto: false


### PR DESCRIPTION
# 변경점 👍
1. Tag 저장 및 확인 기능을 따로 분류
- 본래 Board 엔티티에서 tag를 저장하던 것을 Tag 엔티티를 따로 분류해 분리해서 저장 기능을 만들었습니다. 태그를 통한 게시글 분류를 위한 것으로 Board 엔티티 내에는 여전히 List<String>으로 구현해두었습니다.
 
# 스크린샷 🖼

 1-1. 태그 저장 방법 (form-data)
<img width="1148" alt="스크린샷 2023-01-28 오후 5 24 52" src="https://user-images.githubusercontent.com/77785750/215257409-9714c8c1-b58f-484e-ae1f-555212638ec8.png">
1-2. DB 저장 시
<img width="1107" alt="스크린샷 2023-01-28 오후 5 24 57" src="https://user-images.githubusercontent.com/77785750/215257408-f2dbec5a-5801-48d5-a1b9-11fcaf2aa912.png">
1-3. 태그 보여지는 방법
<img width="1148" alt="스크린샷 2023-01-28 오후 5 59 41" src="https://user-images.githubusercontent.com/77785750/215257404-a2694a27-cc00-4c54-a6a2-3a7f4dda572f.png">

# 비고 ✏
추후 개발해야 할 기능들:
1. 태그 업데이트 및 삭제
2. 태그 분류
 
 <br>
