### PR TITLE
Tag 업데이트 및 삭제 구현

### DIFF
--- a/src/main/java/apptive/fruitable/board/controller/PostController.java
+++ b/src/main/java/apptive/fruitable/board/controller/PostController.java
@@ -6,6 +6,7 @@ import apptive.fruitable.board.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -85,14 +86,15 @@ public class PostController {
     @CrossOrigin
     public ResponseEntity<?> update(@PathVariable Long postId,
                                     @Valid @RequestPart(value = "requestDto") PostRequestDto requestDto,
-                                    @RequestPart(value = "images") List<MultipartFile> photoFileList) {
+                                    @RequestPart(value = "images") List<MultipartFile> photoFileList,
+                                    @RequestPart(value = "tags") List<String> contentList) {
 
         if(postId == null) {
             return new ResponseEntity<>("게시글이 존재하는지 확인해주세요.", HttpStatus.BAD_REQUEST);
         }
 
         try {
-            postService.update(postId, requestDto, photoFileList);
+            postService.update(postId, requestDto, photoFileList, contentList);
             return new ResponseEntity<>("업데이트에 성공했습니다.", HttpStatus.OK);
         } catch (IOException e) {
             return new ResponseEntity<>("게시글 업데이트에 실패했습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/apptive/fruitable/board/repository/TagRepository.java
+++ b/src/main/java/apptive/fruitable/board/repository/TagRepository.java
@@ -1,7 +1,9 @@
 package apptive.fruitable.board.repository;
 
+import apptive.fruitable.board.domain.post.Post;
 import apptive.fruitable.board.domain.tag.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    void deleteAllByPost(Post post);
 }

--- a/src/main/java/apptive/fruitable/board/service/PostService.java
+++ b/src/main/java/apptive/fruitable/board/service/PostService.java
@@ -39,17 +39,7 @@ public class PostService {
         post.updatePost(requestDto);
 
         //태그 등록
-        List<String> tagList = tagService.saveTag(post, contentList);
-        post.setTagList(tagList);
-
-        //이미지 등록
-        List<String> filePath = s3Uploader.uploadFiles(files);
-        List<String> fileURL = new ArrayList<>();
-        for (String url : filePath) {
-            fileURL.add(s3Uploader.getFile(url));
-        }
-        post.setFilePath(filePath);
-        post.setFileURL(fileURL);
+        saveUpdate(files, contentList, post);
 
         postRepository.save(post);
 
@@ -92,6 +82,8 @@ public class PostService {
 
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        tagService.deleteTag(post);
         postRepository.deleteById(id);
     }
 
@@ -99,12 +91,28 @@ public class PostService {
     public Long update(
             Long id,
             PostRequestDto requestDto,
-            List<MultipartFile> files
+            List<MultipartFile> files,
+            List<String> contentList
     ) throws IOException {
 
         //상품 수정
         Post post = postRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
+
+        //태그 업데이트 및 사진 업데이트
+        tagService.deleteTag(post);
+        saveUpdate(files, contentList, post);
+
+        post.updatePost(requestDto);
+
+        postRepository.save(post);
+
+        return post.getId();
+    }
+
+    private void saveUpdate(List<MultipartFile> files, List<String> contentList, Post post) {
+        List<String> tagList = tagService.saveTag(post, contentList);
+        post.setTagList(tagList);
 
         List<String> filePath = s3Uploader.uploadFiles(files);
 
@@ -115,11 +123,5 @@ public class PostService {
 
         post.setFilePath(filePath);
         post.setFileURL(fileURL);
-
-        post.updatePost(requestDto);
-
-        postRepository.save(post);
-
-        return post.getId();
     }
 }

--- a/src/main/java/apptive/fruitable/board/service/TagService.java
+++ b/src/main/java/apptive/fruitable/board/service/TagService.java
@@ -8,6 +8,7 @@ import apptive.fruitable.board.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ public class TagService {
 
     private final TagRepository tagRepository;
 
+    @Transactional
     public List<String> saveTag(Post post, List<String> contentList) {
 
         List<String> tagList = new ArrayList<>();
@@ -38,5 +40,10 @@ public class TagService {
         }
 
         return tagList;
+    }
+
+    public void deleteTag(Post post) {
+
+        tagRepository.deleteAllByPost(post);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,8 @@ cloud:
     s3:
       bucket: fruitable-bucket
     credentials:
-      access-key: AKIA36W7FXMSOMKY4IGK
-      secret-key: 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
+      access-key:
+      secret-key:
     region:
       static: ap-northeast-2
       auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,8 @@ cloud:
     s3:
       bucket: fruitable-bucket
     credentials:
-      access-key:
-      secret-key:
+      access-key: AKIA36W7FXMSOMKY4IGK
+      secret-key: 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
     region:
       static: ap-northeast-2
       auto: false


### PR DESCRIPTION
# 변경점 👍
1. Tag 업데이트 기능 구현
2. Tag 삭제 기능 구현
 
# 스크린샷 🖼

1-1. 업데이트 전 (2번 포스트의 태그)
<img width="1105" alt="스크린샷 2023-01-29 오후 3 03 41" src="https://user-images.githubusercontent.com/77785750/215308575-b6001e18-ec9a-4d36-8824-b7e2bab1bf04.png">
1-2. 업데이트 후 (2번 포스트의 태그)
업데이트 성공 시, "업데이트에 성공했습니다."라는 문구가 뜸
<img width="1106" alt="스크린샷 2023-01-29 오후 3 04 28" src="https://user-images.githubusercontent.com/77785750/215308578-9de4debc-9234-42f7-a4af-e5df98574250.png">

2-1. 태그 삭제 (3번 포스트)
<img width="965" alt="스크린샷 2023-01-29 오후 3 10 52" src="https://user-images.githubusercontent.com/77785750/215308639-c005ab65-f6ed-4bd7-b818-61058da8cad4.png">
2-2. 삭제 시 포스트 삭제
<img width="1106" alt="스크린샷 2023-01-29 오후 3 04 54" src="https://user-images.githubusercontent.com/77785750/215308635-62ab9378-a6c0-4cd0-9b96-208b7c3b67ee.png">
2-3. 삭제 시 태그도 함께 삭제
<img width="1104" alt="스크린샷 2023-01-29 오후 3 05 03" src="https://user-images.githubusercontent.com/77785750/215308637-1684a270-d49c-4ef6-95e7-c98810cd54fa.png">

# 비고 ✏
 태그 CRUD를 완성했습니다. 추후 태그 분류 기능 구현하겠습니다.
 
 <br>
